### PR TITLE
#9 feat/admin 하위 경로 접근 차단 및 인증 플로우 분리

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { AuthProvider } from './contexts/AuthContext';
+import ProtectedRoute from './components/ProtectedRoute';
 import UserHome from './pages/UserHome';
 import AdminHome from './pages/AdminHome';
 import Books from './pages/Books';
 import BookShelf from './pages/BookShelf';
 import Chat from './pages/Chat';
+import AdminAuth from './pages/AdminAuth';
 import './App.css';
 
 /**
@@ -14,29 +17,50 @@ import './App.css';
  */
 function App() {
   return (
-    <Router>
-      <div className="App">
-        {/* 라우트 설정 */}
-        <Routes>
-          {/* 사용자 메인 페이지 (기본 페이지) */}
-          <Route path="/" element={<UserHome />} />
-          
-          {/* 관리자 페이지들 */}
-          <Route path="/admin" element={<AdminHome />} />
-          <Route path="/admin/books" element={<Books />} />
-          <Route path="/admin/book-shelf" element={<BookShelf />} />
-          
-          {/* 관리자 페이지로 리다이렉트 */}
-          <Route path="/books" element={<Navigate to="/admin/books" replace />} />
-          <Route path="/book-shelf" element={<Navigate to="/admin/book-shelf" replace />} />
-          
-          {/* 기본 리다이렉트 - 잘못된 경로는 사용자 메인 페이지로 */}
-          <Route path="*" element={<Navigate to="/" replace />} />
-          {/* Chat 페이지 */}
-          <Route path="/chat" element={<Chat />} /> 
-        </Routes>
-      </div>
-    </Router>
+    <AuthProvider>
+      <Router>
+        <div className="App">
+          <Routes>
+            <Route path="/" element={<UserHome />} />
+
+            {/* 관리자 인증 페이지(보호하지 않음) */}
+            <Route path="/admin/auth" element={<AdminAuth />} />
+
+            {/* 관리자 모든 하위 경로 보호 */}
+            <Route
+              path="/admin"
+              element={
+                <ProtectedRoute>
+                  <AdminHome />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/books"
+              element={
+                <ProtectedRoute>
+                  <Books />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/book-shelf"
+              element={
+                <ProtectedRoute>
+                  <BookShelf />
+                </ProtectedRoute>
+              }
+            />
+
+            {/* Chat 페이지 */}
+            <Route path="/chat" element={<Chat />} />
+
+            {/* 기본 리다이렉트 */}
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </div>
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,78 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import '../styles/ProtectedRoute.css';
+
+const ProtectedRoute = ({ children }) => {
+  const { isAdminAuthenticated, adminLogin } = useAuth();
+  const [showPasswordPrompt, setShowPasswordPrompt] = useState(!isAdminAuthenticated);
+  const [adminCodeInput, setAdminCodeInput] = useState('');
+  const [authError, setAuthError] = useState('');
+  const inputRef = useRef(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    if (showPasswordPrompt && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [showPasswordPrompt]);
+
+  const handleAdminSubmit = (e) => {
+    e.preventDefault();
+    setAuthError('');
+    
+    if (adminLogin(adminCodeInput)) {
+      setShowPasswordPrompt(false);
+      setAdminCodeInput('');
+    } else {
+      setAuthError('잘못된 관리자 코드입니다.');
+      setAdminCodeInput('');
+      inputRef.current?.focus();
+    }
+  };
+
+  if (showPasswordPrompt) {
+    return (
+      <div className="admin-auth-overlay">
+        <div className="admin-auth-modal">
+          <h2>🔐 관리자 인증</h2>
+          <p>관리자 페이지에 접근하려면 인증 코드를 입력하세요.</p>
+          
+          <form onSubmit={handleAdminSubmit}>
+            <input
+              ref={inputRef}
+              type="password"
+              value={adminCodeInput}
+              onChange={(e) => setAdminCodeInput(e.target.value)}
+              placeholder="관리자 코드 입력"
+              className="admin-code-input"
+            />
+            
+            {authError && <p className="auth-error">{authError}</p>}
+            
+            <div className="auth-buttons">
+              <button type="submit" className="auth-submit-btn">
+                확인
+              </button>
+              <button 
+                type="button" 
+                className="auth-cancel-btn"
+                onClick={() => window.history.back()}
+              >
+                취소
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAdminAuthenticated) {
+    return <Navigate to="/admin/auth" replace state={{ from: location }} />;
+  }
+  
+  return children;
+};
+
+export default ProtectedRoute;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const AuthContext = createContext();
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export const AuthProvider = ({ children }) => {
+  const [isAdminAuthenticated, setIsAdminAuthenticated] = useState(false);
+
+  useEffect(() => {
+    // 페이지 새로고침 시 세션스토리지에서 인증 상태 복원
+    const authStatus = sessionStorage.getItem('adminAuth');
+    if (authStatus === 'true') {
+      setIsAdminAuthenticated(true);
+    }
+  }, []);
+
+  const adminLogin = (code) => {
+    const correctCode = process.env.REACT_APP_ADMIN_CODE || '1234';
+    if (code === correctCode) {
+      setIsAdminAuthenticated(true);
+      sessionStorage.setItem('adminAuth', 'true');
+      return true;
+    }
+    return false;
+  };
+
+  const adminLogout = () => {
+    setIsAdminAuthenticated(false);
+    sessionStorage.removeItem('adminAuth');
+  };
+
+  return (
+    <AuthContext.Provider value={{
+      isAdminAuthenticated,
+      adminLogin,
+      adminLogout
+    }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/pages/AdminAuth.jsx
+++ b/src/pages/AdminAuth.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import '../styles/ProtectedRoute.css';
+
+const AdminAuth = () => {
+  const { isAdminAuthenticated, adminLogin } = useAuth();
+  const navigate = useNavigate();
+  const [adminCodeInput, setAdminCodeInput] = useState('');
+  const [authError, setAuthError] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (isAdminAuthenticated) {
+      navigate('/admin', { replace: true });
+    }
+  }, [isAdminAuthenticated, navigate]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setAuthError('');
+    if (adminLogin(adminCodeInput)) {
+      navigate('/admin', { replace: true });
+    } else {
+      setAuthError('잘못된 관리자 코드입니다.');
+      setAdminCodeInput('');
+      inputRef.current?.focus();
+    }
+  };
+
+  return (
+    <div className="admin-auth-overlay">
+      <div className="admin-auth-modal">
+        <h2>🔐 관리자 인증</h2>
+        <p>관리자 페이지에 접근하려면 인증 코드를 입력하세요.</p>
+
+        <form onSubmit={handleSubmit}>
+          <input
+            ref={inputRef}
+            type="password"
+            value={adminCodeInput}
+            onChange={(e) => setAdminCodeInput(e.target.value)}
+            placeholder="관리자 코드 입력"
+            className="admin-code-input"
+            aria-label="관리자 코드 입력"
+          />
+          {authError && <p className="auth-error">{authError}</p>}
+
+          <div className="auth-buttons">
+            <button type="submit" className="auth-submit-btn">확인</button>
+            <button type="button" className="auth-cancel-btn" onClick={() => navigate('/', { replace: true })}>
+              취소
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AdminAuth;

--- a/src/pages/AdminHome.jsx
+++ b/src/pages/AdminHome.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+// import { useAuth } from '../contexts/AuthContext'; // 제거
+// import { useNavigate } from 'react-router-dom';    // 제거
 import Header from '../components/Header';
 import SearchBar from '../components/SearchBar';
 import ScanControls from '../components/ScanControls';
@@ -9,26 +10,15 @@ import '../styles/Home.css';
 
 /**
  * 관리자 메인 페이지 컴포넌트
- * 도서관 관리 시스템의 관리자 화면
- * 검색 기능, 스캔 제어, 검색 결과 표시를 포함
+ * ProtectedRoute에서 인증을 처리하므로, 이 컴포넌트는 별도 인증 로직이 없습니다.
  */
 const AdminHome = () => {
   // 검색 결과 상태 관리
   const [searchResults, setSearchResults] = useState([]);
-  // 검색 중 로딩 상태 관리
   const [isSearching, setIsSearching] = useState(false);
-  // 검색 실행 여부 상태 관리
   const [hasSearched, setHasSearched] = useState(false);
 
-  // 관리자 인증 관련 상태
-  const [isAuthorized, setIsAuthorized] = useState(false);
-  const [showPasswordPrompt, setShowPasswordPrompt] = useState(true);
-  const [adminCodeInput, setAdminCodeInput] = useState('');
-  const [authError, setAuthError] = useState('');
-  const inputRef = useRef(null);
-  const navigate = useNavigate();
-
-  // 화면 스케일링(1920x1200 기준) — iPad 1920*1200 환경에 맞춰 반응형 처리
+  // 화면 스케일링(1920x1200 기준)
   const [scale, setScale] = useState(1);
   useEffect(() => {
     const computeScale = () => {
@@ -42,21 +32,11 @@ const AdminHome = () => {
     return () => window.removeEventListener('resize', computeScale);
   }, []);
 
-  useEffect(() => {
-    if (showPasswordPrompt && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [showPasswordPrompt]);
-
-  /**
-   * 도서 검색 실행 함수
-   * @param {string} query - 검색어
-   */
+  // 도서 검색
   const handleSearch = async (query) => {
     try {
       setIsSearching(true);
       setHasSearched(true);
-
       const results = await ApiService.searchBooks(query);
       setSearchResults(results);
     } catch (error) {
@@ -68,44 +48,10 @@ const AdminHome = () => {
     }
   };
 
-  /**
-   * 검색 결과 초기화 함수
-   */
+  // 검색 결과 초기화
   const handleClearSearch = () => {
     setSearchResults([]);
     setHasSearched(false);
-  };
-
-  // 관리자 코드 검증 (환경변수 REACT_APP_ADMIN_CODE 사용, 없으면 기본 '1234')
-  const verifyAdminCode = (code) => {
-    const expected = process.env.REACT_APP_ADMIN_CODE || '1234';
-    return code.trim() === expected;
-  };
-
-  const handleAdminSubmit = (e) => {
-    e.preventDefault();
-    if (verifyAdminCode(adminCodeInput)) {
-      setIsAuthorized(true);
-      setShowPasswordPrompt(false);
-      setAuthError('');
-      setAdminCodeInput('');
-    } else {
-      setAuthError('암호 코드가 올바르지 않습니다.');
-      setIsAuthorized(false);
-      setShowPasswordPrompt(true);
-      setAdminCodeInput('');
-      if (inputRef.current) inputRef.current.focus();
-    }
-  };
-
-  const handleAdminCancel = () => {
-    // 인증 취소 시 사용자 페이지로 이동
-    setAdminCodeInput('');
-    setAuthError('');
-    setShowPasswordPrompt(true);
-    setIsAuthorized(false);
-    // '/' 경로를 사용자 홈으로 가정하여 이동 처리
-    navigate('/');
   };
 
   return (
@@ -118,128 +64,20 @@ const AdminHome = () => {
         margin: '0 auto',
       }}
     >
-      {/* 헤더 컴포넌트 */}
       <Header />
 
-      {/* 관리자 비밀번호 프롬프트(페이지 진입 시 반드시 입력) */}
-      {showPasswordPrompt && (
-        <div
-          style={{
-            position: 'fixed',
-            inset: 0,
-            background: 'rgba(0,0,0,0.6)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 9999,
-          }}
-        >
-          <form
-            onSubmit={handleAdminSubmit}
-            style={{
-              background: '#fff',
-              padding: 24,
-              borderRadius: 8,
-              width: 420,
-              maxWidth: '90%',
-              boxShadow: '0 4px 18px rgba(0,0,0,0.25)',
-            }}
-          >
-            <h2 style={{ marginTop: 0, marginBottom: 8 }}>관리자 인증</h2>
-            <p style={{ marginTop: 0, marginBottom: 16 }}>
-              관리자 화면에 접근하려면 암호 코드를 입력하세요.
-            </p>
-            <input
-              ref={inputRef}
-              type="password"
-              value={adminCodeInput}
-              onChange={(e) => setAdminCodeInput(e.target.value)}
-              placeholder="암호 코드 입력"
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                fontSize: 16,
-                marginBottom: 8,
-                boxSizing: 'border-box',
-              }}
-            />
-            {authError && (
-              <div style={{ color: 'crimson', marginBottom: 8 }}>{authError}</div>
-            )}
-            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-              <button
-                type="button"
-                onClick={handleAdminCancel}
-                style={{
-                  padding: '8px 12px',
-                  background: '#eee',
-                  border: 'none',
-                  borderRadius: 4,
-                  cursor: 'pointer',
-                }}
-              >
-                취소
-              </button>
-              <button
-                type="submit"
-                style={{
-                  padding: '8px 12px',
-                  background: '#0066cc',
-                  color: '#fff',
-                  border: 'none',
-                  borderRadius: 4,
-                  cursor: 'pointer',
-                }}
-              >
-                인증
-              </button>
-            </div>
-          </form>
-        </div>
-      )}
-
       <main className="main-content" style={{ padding: 24 }}>
-        {/* 도서관 이미지 컨테이너 (반응형 스케일로 처리되어 있어 주석 유지) */}
-        {/* <div className="image-container">
-          <img 
-            src="/images/image2.png" 
-            alt="도서관 이미지 2" 
-            className="library-image"
-            onError={(e) => {
-              e.target.src = '/default-library.jpg';
-            }}
-          />
-          <img 
-            src="/images/image1.png" 
-            alt="도서관 이미지 1" 
-            className="library-image"
-            onError={(e) => {
-              e.target.src = '/default-library.jpg';
-            }}
-          />
-          <img 
-            src="/images/image3.png" 
-            alt="도서관 이미지 3" 
-            className="library-image"
-            onError={(e) => {
-              e.target.src = '/default-library.jpg';
-            }}
-          />
-        </div> */}
-
         {/* 검색 섹션 */}
         <section className="search-section">
           <SearchBar
             onSearch={handleSearch}
-            disabled={isSearching || !isAuthorized}
+            disabled={isSearching}
           />
 
-          {/* 검색 결과 초기화 버튼 */}
           {hasSearched && (
             <button
               className="clear-results-button"
               onClick={handleClearSearch}
-              disabled={!isAuthorized}
             >
               검색 결과 지우기
             </button>
@@ -280,7 +118,7 @@ const AdminHome = () => {
 
         {/* 스캔 제어 섹션 */}
         <section className="scan-section">
-          <ScanControls disabled={!isAuthorized} />
+          <ScanControls />
         </section>
       </main>
     </div>

--- a/src/pages/UserHome.jsx
+++ b/src/pages/UserHome.jsx
@@ -5,12 +5,14 @@ import BookCard from '../components/BookCard';
 import ApiService from '../services/api';
 import '../styles/UserHome.css';
 import ChatButton from '../components/ChatButton';
+import { useAuth } from '../contexts/AuthContext';
 /**
  * 사용자 메인 페이지 컴포넌트
  * 간단한 도서 검색 기능과 관리자 페이지로의 링크를 제공
  */
 const UserHome = () => {
   const navigate = useNavigate();
+  const { adminLogout } = useAuth();
   // 검색 결과 상태 관리
   const [searchResults, setSearchResults] = useState([]);
   // 검색 중 로딩 상태 관리
@@ -50,7 +52,8 @@ const UserHome = () => {
    * 관리자 페이지로 이동하는 함수
    */
   const handleGoToAdmin = () => {
-    navigate('/admin');
+    adminLogout();              // 기존 인증 상태 제거
+    navigate('/admin/auth');    // 인증 페이지로 이동
   };
   /*임시 목 데이터*/
 const mockPopularBooks = [

--- a/src/styles/ProtectedRoute.css
+++ b/src/styles/ProtectedRoute.css
@@ -1,0 +1,71 @@
+/* Place your CSS styles for ProtectedRoute here */
+
+/* 관리자 인증 오버레이 기본 스타일 */
+.admin-auth-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.admin-auth-modal {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 12px;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 18px 48px rgba(0,0,0,0.25);
+  text-align: center;
+}
+
+.admin-auth-modal h2 {
+  margin: 0 0 0.75rem;
+}
+
+.admin-code-input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 1rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.admin-code-input:focus {
+  outline: none;
+  border-color: #0b66ff;
+}
+
+.auth-error {
+  color: #e11d48;
+  margin: 0.4rem 0 0.8rem;
+}
+
+.auth-buttons {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: center;
+}
+
+.auth-submit-btn, .auth-cancel-btn {
+  padding: 0.6rem 1.1rem;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.auth-submit-btn {
+  background: #0b66ff;
+  color: #fff;
+  border: none;
+}
+
+.auth-cancel-btn {
+  background: #f8f9fa;
+  color: #333;
+  border: 1px solid #e5e7eb;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- ProtectedRoute를 리다이렉트 가드로 단일 책임화
- AdminAuth 페이지 추가(코드 입력/검증, 성공 시 /admin 이동)
- App.js: /admin/* 라우트 ProtectedRoute로 보호, /admin/auth 공개 라우트 추가
- UserHome: 관리자 버튼 클릭 시 /admin/auth로 이동 + 세션 초기화(adminLogout)
- AuthContext: 세션스토리지로 인증 상태 복원/저장
- AdminHome: 기존 인증 프롬프트/로직 제거
- ProtectedRoute.css 스타일 정리
- api.js 경로/경고 정리

### 스크린샷 (선택)

https://github.com/user-attachments/assets/ad2cfe31-ee30-4d6d-818b-ed36ea243d8b

